### PR TITLE
fix: cpu-ram-crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,14 @@ services:
     networks:
       - portabase
 
+    cpus: "1.50"
+
+    mem_limit: 4g
+    memswap_limit: 4g
+
+    pids_limit: 512
+
+
 volumes:
   cargo-registry:
   cargo-git:

--- a/src/domain/mariadb/restore.rs
+++ b/src/domain/mariadb/restore.rs
@@ -2,7 +2,6 @@ use crate::services::backup::logger::JobLogger;
 use crate::services::config::DatabaseConfig;
 use anyhow::{Context, Result};
 use std::fs::File;
-use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -12,11 +11,8 @@ pub async fn run(cfg: DatabaseConfig, restore_file: PathBuf, logger: Arc<JobLogg
     let handle = tokio::task::spawn_blocking(move || -> Result<()> {
         logger.log("info", format!("Starting restore for database {}", cfg.name));
 
-        let mut sql_content = String::new();
         let mut file = File::open(&restore_file)
             .with_context(|| format!("Failed to open restore file {}", restore_file.display()))?;
-        file.read_to_string(&mut sql_content)
-            .with_context(|| format!("Failed to read restore file {}", restore_file.display()))?;
 
         let drop_create_cmd = format!(
             "DROP DATABASE IF EXISTS `{0}`; CREATE DATABASE `{0}`;",
@@ -66,10 +62,8 @@ pub async fn run(cfg: DatabaseConfig, restore_file: PathBuf, logger: Arc<JobLogg
             .with_context(|| format!("Failed to start MariaDB restore for {}", cfg.name))?;
 
         let mut stdin = child.stdin.take().context("Failed to open child stdin")?;
-        stdin
-            .write_all(sql_content.as_bytes())
-            .context("Failed to write SQL content to MariaDB stdin")?;
-        stdin.flush()?;
+        std::io::copy(&mut file, &mut stdin)
+            .context("Failed to stream SQL content to MariaDB stdin")?;
         drop(stdin);
 
         let output = child

--- a/src/domain/mysql/restore.rs
+++ b/src/domain/mysql/restore.rs
@@ -2,7 +2,6 @@ use crate::services::backup::logger::JobLogger;
 use crate::services::config::DatabaseConfig;
 use anyhow::{Context, Result};
 use std::fs::File;
-use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -12,11 +11,8 @@ pub async fn run(cfg: DatabaseConfig, restore_file: PathBuf, logger: Arc<JobLogg
     let handle = tokio::task::spawn_blocking(move || -> Result<()> {
         logger.log("info", format!("Starting restore for database {}", cfg.name));
 
-        let mut sql_content = String::new();
         let mut file = File::open(&restore_file)
             .with_context(|| format!("Failed to open restore file {}", restore_file.display()))?;
-        file.read_to_string(&mut sql_content)
-            .with_context(|| format!("Failed to read restore file {}", restore_file.display()))?;
 
         let drop_create_cmd = format!(
             "DROP DATABASE IF EXISTS `{0}`; CREATE DATABASE `{0}`;",
@@ -66,10 +62,8 @@ pub async fn run(cfg: DatabaseConfig, restore_file: PathBuf, logger: Arc<JobLogg
             .with_context(|| format!("Failed to start mysql restore for {}", cfg.name))?;
 
         let mut stdin = child.stdin.take().context("Failed to open child stdin")?;
-        stdin
-            .write_all(sql_content.as_bytes())
-            .context("Failed to write SQL content to mysql stdin")?;
-        stdin.flush()?;
+        std::io::copy(&mut file, &mut stdin)
+            .context("Failed to stream SQL content to mysql stdin")?;
         drop(stdin);
 
         let output = child


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * Explicit container resource limits (CPU allocation, memory caps, and process limits) are now applied to ensure consistent application behavior and prevent resource exhaustion.
  * Database restore operations for MySQL and MariaDB have been optimized with direct streaming, significantly reducing memory consumption and improving efficiency during restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->