### PR TITLE
Dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,19 +249,20 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -320,14 +321,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -420,13 +421,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -461,7 +462,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -508,18 +509,18 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -836,7 +837,7 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-named-pipe",
  "hyper-rustls 0.27.7",
  "hyper-util",
@@ -845,7 +846,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -932,6 +933,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1177,9 +1181,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -1434,6 +1447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "ctutils",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +1512,7 @@ dependencies = [
  "der",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1506,7 +1530,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1874,6 +1898,226 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a300d4011cb53573eafe2419630d303ced54aab6c194a6d9e4156de375800372"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "reqwest 0.13.4",
+ "rustc_version",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f60f45dd97ff91cedfcb6b2b9f860d3d84739386c3557027687c52cc0e698fd"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "pin-project",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e0d5b25e5714321efc3ea48a1457bcd943ba85fe7a0e80e97d989f3c9aea17"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "h2 0.4.15",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-types",
+ "reqwest 0.13.4",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a245c548c002e22d1644e88d9b7d6c32183b335e63510a1bb8580045c3282d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de120149ea50fd0cccc2d3dfb863bc23e398ead386fa59c5d8f8f6004ced01c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40d4311479512e408b67777cf497dac6e41fbe8c96730416ed9d47855584b29"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b177796075b7bfc02bf2e405db665ee850a924fa44cedfc5282b473c5ab203"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f796d8a7a5b1457ecd5ebb0451bf0502e15127cf42195591ffea90092fa82551"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "md5",
+ "percent-encoding",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3658f2192252ba301a9d0a26e298bd56b55f0edb32de499a2f41ff244c09cf8"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e0186e2221bf82c5296500251b4650b111172c324984159a0de9f6bcaa18a5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2018,7 +2262,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2132,22 +2385,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2160,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2190,9 +2442,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -2207,7 +2459,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2226,7 +2478,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2247,7 +2499,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2510,6 +2762,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,8 +2919,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -2688,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -2775,7 +3049,7 @@ dependencies = [
  "hex",
  "hickory-proto",
  "hickory-resolver",
- "hmac",
+ "hmac 0.12.1",
  "macro_magic",
  "md-5",
  "mongocrypt",
@@ -2784,13 +3058,13 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "rustc_version_runtime",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_with",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.3",
  "stringprep",
  "strsim",
@@ -2938,7 +3212,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3022,6 +3296,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,7 +3345,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3098,7 +3408,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3128,18 +3438,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3214,8 +3524,10 @@ dependencies = [
  "futures",
  "futures-util",
  "generic-array",
+ "google-cloud-auth",
+ "google-cloud-storage",
  "hex",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "log",
  "mockall",
  "mongodb",
@@ -3225,7 +3537,7 @@ dependencies = [
  "postgres",
  "rand 0.9.2",
  "redis",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tar",
@@ -3280,11 +3592,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "memchr",
  "rand 0.9.2",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
 ]
 
@@ -3428,7 +3740,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3449,7 +3761,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3693,7 +4005,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -3701,7 +4013,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3721,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3731,11 +4043,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -3745,7 +4057,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -3778,7 +4090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -3792,7 +4104,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3848,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3916,7 +4228,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.9",
@@ -3939,7 +4251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3951,7 +4263,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4021,7 +4333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4122,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -4216,7 +4528,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4233,7 +4545,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4267,7 +4590,16 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
  "rand_core 0.6.4",
 ]
 
@@ -4669,9 +5001,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4686,9 +5018,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4737,7 +5069,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -4830,18 +5162,20 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs 0.8.3",
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -4971,6 +5305,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,7 +5398,7 @@ dependencies = [
  "futures",
  "pin-project",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "time",
@@ -5131,6 +5479,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5144,7 +5498,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -5195,9 +5549,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5879,7 +6233,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -6084,6 +6438,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ aws-config = "1.8.13"
 aws-sdk-s3 = { version = "1.122.0", features = ["behavior-version-latest"] }
 azure_core = "1.0.0"
 azure_storage_blob = "1.0.0"
+google-cloud-storage = "1.15"
+google-cloud-auth = "1.13"
 async-compression = { version = "0.4.37", features = ["tokio", "gzip"] }
 tokio-tar = "0.3.1"
 oauth2 = "5.0.0"

--- a/databases.json
+++ b/databases.json
@@ -111,15 +111,6 @@
       "port": 1433,
       "host": "db-mssql",
       "generated_id": "16706125-ff7e-4c97-8c83-0adeff214682"
-    },
-    {
-      "name": "Test database - PostgreSQL cluster",
-      "type": "postgresql-cluster",
-      "username": "nextclouddbuser",
-      "password": "50AL2Oh5IXajbOAxfJ",
-      "port": 5432,
-      "host": "nextcloud-db",
-      "generated_id": "16678199-ff7e-4c97-8c83-0adeff214681"
     }
   ]
 }

--- a/databases.json
+++ b/databases.json
@@ -111,6 +111,15 @@
       "port": 1433,
       "host": "db-mssql",
       "generated_id": "16706125-ff7e-4c97-8c83-0adeff214682"
+    },
+    {
+      "name": "Test database - PostgreSQL cluster",
+      "type": "postgresql-cluster",
+      "username": "nextclouddbuser",
+      "password": "50AL2Oh5IXajbOAxfJ",
+      "port": 5432,
+      "host": "nextcloud-db",
+      "generated_id": "16678199-ff7e-4c97-8c83-0adeff214681"
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       APP_ENV: development
       LOG: debug
       TZ: "Europe/Paris"
-      EDGE_KEY: "eyJzZXJ2ZXJVcmwiOiJodHRwOi8vbG9jYWxob3N0Ojg4ODciLCJhZ2VudElkIjoiNWRkZTE1NTctZWQ1ZC00MjUxLThiZDMtMDE0MjkxOTg2OGZjIiwibWFzdGVyS2V5QjY0IjoiQlhWM1hvbEM2NTZTVjdkTmdjV1BHUWxrKytycExJNmxHRGk3Q1BCNWllbz0ifQ=="
+      EDGE_KEY: "eyJzZXJ2ZXJVcmwiOiJodHRwOi8vbG9jYWxob3N0Ojg4ODciLCJhZ2VudElkIjoiNzY1OGIzYjctNjg5MC00MjllLThkN2QtNjU2ZjlmYTJlMDRjIiwibWFzdGVyS2V5QjY0IjoiQlhWM1hvbEM2NTZTVjdkTmdjV1BHUWxrKytycExJNmxHRGk3Q1BCNWllbz0ifQ=="
       #CHUNK_SIZE_MB: "1"
       #POOLING: 1
       #DATABASES_CONFIG_FILE: "config.toml"
@@ -27,12 +27,9 @@ services:
       - "localhost:host-gateway"
     networks:
       - portabase
-
     cpus: "1.50"
-
     mem_limit: 4g
     memswap_limit: 4g
-
     pids_limit: 512
 
 

--- a/src/domain/factory.rs
+++ b/src/domain/factory.rs
@@ -1,5 +1,6 @@
 use crate::domain::mongodb::database::MongoDatabase;
 use crate::domain::mysql::database::MySQLDatabase;
+use crate::domain::postgres::cluster::database::PostgresClusterDatabase;
 use crate::domain::postgres::database::PostgresDatabase;
 use crate::domain::postgres::{detect_format_from_file, detect_format_from_size};
 use crate::domain::redis::database::RedisDatabase;
@@ -31,6 +32,7 @@ impl DatabaseFactory {
                 let format = detect_format_from_size(&cfg).await;
                 Arc::new(PostgresDatabase::new(cfg, format))
             }
+            DbType::PostgresqlCluster => Arc::new(PostgresClusterDatabase::new(cfg)),
             DbType::Mysql => Arc::new(MySQLDatabase::new(cfg)),
             DbType::Mariadb => Arc::new(MariaDBDatabase::new(cfg)),
             DbType::MongoDB => Arc::new(MongoDatabase::new(cfg)),
@@ -48,6 +50,7 @@ impl DatabaseFactory {
                 let format = detect_format_from_file(restore_file);
                 Arc::new(PostgresDatabase::new(cfg, format))
             }
+            DbType::PostgresqlCluster => Arc::new(PostgresClusterDatabase::new(cfg)),
             DbType::Mysql => Arc::new(MySQLDatabase::new(cfg)),
             DbType::Mariadb => Arc::new(MariaDBDatabase::new(cfg)),
             DbType::MongoDB => Arc::new(MongoDatabase::new(cfg)),

--- a/src/domain/postgres/cluster/backup.rs
+++ b/src/domain/postgres/cluster/backup.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::super::connection::{
+    is_superuser, pg_dumpall_binary_name, select_pg_path, server_version,
+};
+use crate::services::backup::logger::JobLogger;
+use crate::services::config::DatabaseConfig;
+
+pub async fn run(
+    cfg: DatabaseConfig,
+    backup_dir: PathBuf,
+    env: HashMap<String, String>,
+    logger: Arc<JobLogger>,
+) -> Result<PathBuf> {
+    tokio::task::spawn_blocking(move || -> Result<PathBuf> {
+        logger.log("info", format!("Starting cluster backup for {}", cfg.name));
+
+        let version = match futures::executor::block_on(server_version(&cfg)) {
+            Ok(v) => v,
+            Err(e) => {
+                logger.log("error", format!("Failed to get server version for {}: {:?}", cfg.name, e));
+                return Err(e.into());
+            }
+        };
+
+        match futures::executor::block_on(is_superuser(&cfg)) {
+            Ok(true) => {}
+            Ok(false) => {
+                logger.log("error", format!("postgresql-cluster backup requires a superuser role for {}", cfg.name));
+                anyhow::bail!("postgresql-cluster backup requires a superuser role for {}", cfg.name);
+            }
+            Err(e) => {
+                logger.log("error", format!("Failed to check superuser status for {}: {:?}", cfg.name, e));
+                return Err(e.into());
+            }
+        }
+
+        let pg_dumpall = select_pg_path(&version).join(pg_dumpall_binary_name());
+        let file_path = backup_dir.join(format!("{}.sql", cfg.generated_id));
+
+        logger.log("info", format!("Running pg_dumpall for cluster {} via {:?}", cfg.name, pg_dumpall));
+
+        let start = Instant::now();
+        let output = Command::new(&pg_dumpall)
+            .arg("--host").arg(&cfg.host)
+            .arg("--port").arg(cfg.port.to_string())
+            .arg("--username").arg(&cfg.username)
+            .arg("-v")
+            .arg("-f").arg(&file_path)
+            .envs(env)
+            .output();
+        let duration_ms = start.elapsed().as_millis() as f64;
+
+        match output {
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+                let exit_code = o.status.code().unwrap_or(-1);
+                if o.status.success() {
+                    logger.log_command("pg_dumpall", if stderr.is_empty() { None } else { Some(stderr) }, Some(0), Some(duration_ms));
+                    logger.log("info", format!("Cluster backup completed for {} at {:?}", cfg.name, file_path));
+                    Ok(file_path)
+                } else {
+                    logger.log_command("pg_dumpall", Some(stderr), Some(exit_code), Some(duration_ms));
+                    anyhow::bail!("Cluster backup (pg_dumpall) failed for {}", cfg.name);
+                }
+            }
+            Err(e) => {
+                logger.log_command("pg_dumpall", Some(e.to_string()), Some(-1), Some(duration_ms));
+                Err(e.into())
+            }
+        }
+    })
+    .await?
+}

--- a/src/domain/postgres/cluster/database.rs
+++ b/src/domain/postgres/cluster/database.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::super::ping;
+use super::{backup, restore};
+use crate::domain::factory::Database;
+use crate::services::backup::logger::JobLogger;
+use crate::services::config::DatabaseConfig;
+use crate::utils::locks::{DbOpLock, FileLock};
+
+pub struct PostgresClusterDatabase {
+    pub cfg: DatabaseConfig,
+}
+
+impl PostgresClusterDatabase {
+    pub fn new(cfg: DatabaseConfig) -> Self {
+        Self { cfg }
+    }
+
+    fn build_env(&self) -> HashMap<String, String> {
+        let mut envs = std::env::vars().collect::<HashMap<_, _>>();
+        envs.insert("PGPASSWORD".to_string(), self.cfg.password.to_string());
+        envs
+    }
+}
+
+#[async_trait]
+impl Database for PostgresClusterDatabase {
+    fn file_extension(&self) -> &'static str {
+        ".sql"
+    }
+
+    async fn ping(&self) -> Result<bool> {
+        ping::run(self.cfg.clone()).await
+    }
+
+    async fn backup(&self, dir: &Path, logger: Arc<JobLogger>) -> Result<PathBuf> {
+        FileLock::acquire(&self.cfg.generated_id, DbOpLock::Backup.as_str()).await?;
+        let res = backup::run(self.cfg.clone(), dir.to_path_buf(), self.build_env(), logger).await;
+        FileLock::release(&self.cfg.generated_id).await?;
+        res
+    }
+
+    async fn restore(&self, file: &Path, logger: Arc<JobLogger>) -> Result<()> {
+        FileLock::acquire(&self.cfg.generated_id, DbOpLock::Restore.as_str()).await?;
+        let res = restore::run(self.cfg.clone(), file.to_path_buf(), self.build_env(), logger).await;
+        FileLock::release(&self.cfg.generated_id).await?;
+        res
+    }
+}

--- a/src/domain/postgres/cluster/mod.rs
+++ b/src/domain/postgres/cluster/mod.rs
@@ -1,0 +1,3 @@
+pub mod backup;
+pub mod database;
+pub mod restore;

--- a/src/domain/postgres/cluster/restore.rs
+++ b/src/domain/postgres/cluster/restore.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::super::connection::{is_superuser, psql_binary_name, select_pg_path, server_version};
+use crate::services::backup::logger::JobLogger;
+use crate::services::config::DatabaseConfig;
+
+pub async fn run(
+    cfg: DatabaseConfig,
+    restore_file: PathBuf,
+    env: HashMap<String, String>,
+    logger: Arc<JobLogger>,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        logger.log("info", format!("Starting cluster restore for {}", cfg.name));
+
+        let version = match futures::executor::block_on(server_version(&cfg)) {
+            Ok(v) => v,
+            Err(e) => {
+                logger.log("error", format!("Failed to get server version for {}: {:?}", cfg.name, e));
+                return Err(e.into());
+            }
+        };
+
+        match futures::executor::block_on(is_superuser(&cfg)) {
+            Ok(true) => {}
+            Ok(false) => {
+                logger.log("error", format!("postgresql-cluster restore requires a superuser role for {}", cfg.name));
+                anyhow::bail!("postgresql-cluster restore requires a superuser role for {}", cfg.name);
+            }
+            Err(e) => {
+                logger.log("error", format!("Failed to check superuser status for {}: {:?}", cfg.name, e));
+                return Err(e.into());
+            }
+        }
+
+        let psql = select_pg_path(&version).join(psql_binary_name());
+
+        logger.log("info", format!("Replaying cluster dump for {} via {:?}", cfg.name, psql));
+
+        let start = Instant::now();
+        let output = Command::new(&psql)
+            .arg("--host").arg(&cfg.host)
+            .arg("--port").arg(cfg.port.to_string())
+            .arg("--username").arg(&cfg.username)
+            .arg("--dbname").arg("postgres")
+            .arg("-f").arg(&restore_file)
+            .envs(env)
+            .output();
+        let duration_ms = start.elapsed().as_millis() as f64;
+
+        match output {
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+                let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+                let combined = format!("{}{}", stdout, stderr);
+                let exit_code = o.status.code().unwrap_or(-1);
+                if o.status.success() {
+                    logger.log_command("psql", if combined.is_empty() { None } else { Some(combined) }, Some(0), Some(duration_ms));
+                    logger.log("info", format!("Cluster restore completed for {}", cfg.name));
+                    Ok(())
+                } else {
+                    logger.log_command("psql", if combined.is_empty() { None } else { Some(combined) }, Some(exit_code), Some(duration_ms));
+                    anyhow::bail!("Cluster restore (psql) failed for {}", cfg.name);
+                }
+            }
+            Err(e) => {
+                logger.log_command("psql", Some(e.to_string()), Some(-1), Some(duration_ms));
+                Err(e.into())
+            }
+        }
+    })
+    .await?
+}

--- a/src/domain/postgres/connection.rs
+++ b/src/domain/postgres/connection.rs
@@ -33,32 +33,21 @@ pub async fn server_version(cfg: &DatabaseConfig) -> Result<String> {
     Ok(version)
 }
 
-/// Resolves the `bin` directory of a PostgreSQL installation for the given
-/// major version, in a cross-platform way.
-///
-/// Resolution order:
-/// 1. The `PG_BIN_DIR` environment variable, if set, is used as-is. This
-///    allows users/CI to override detection for non-standard installs
-///    (e.g. portable PostgreSQL distributions, custom install locations).
-/// 2. Platform-specific default install locations (Debian/Ubuntu packages,
-///    the official Windows installer, Homebrew/Postgres.app on macOS, and
-///    common RPM-based layouts on other Linux distros).
-/// 3. A `PATH` lookup for `pg_dump` (`pg_dump.exe` on Windows), returning
-///    its parent directory.
-/// 4. The historical Debian/Ubuntu path as a last-resort fallback, so the
-///    function keeps returning a `PathBuf` (never panics) even when nothing
-///    was found, preserving the previous behavior for callers.
-///
-/// The override is sourced from `CONFIG.pg_bin_dir` (the `PG_BIN_DIR`
-/// environment variable). An empty value means "unset" and falls through to
-/// detection.
+pub async fn is_superuser(cfg: &DatabaseConfig) -> Result<bool> {
+    let client = connect(cfg).await?;
+    let is_super: bool = client
+        .query_one("SELECT current_setting('is_superuser') = 'on';", &[])
+        .await?
+        .get(0);
+
+    Ok(is_super)
+}
+
+
 pub fn select_pg_path(version: &str) -> std::path::PathBuf {
     select_pg_path_with(version, &CONFIG.pg_bin_dir)
 }
 
-/// Inner resolver behind [`select_pg_path`], parameterized over the
-/// `PG_BIN_DIR` override. Kept pure (no env / no `CONFIG` access) so it is
-/// unit-testable without mutating process-global state.
 pub(crate) fn select_pg_path_with(version: &str, pg_bin_dir: &str) -> std::path::PathBuf {
     let major = version.split('.').next().unwrap_or("17");
 
@@ -106,6 +95,22 @@ pub(crate) fn pg_dump_binary_name() -> &'static str {
         "pg_dump.exe"
     } else {
         "pg_dump"
+    }
+}
+
+pub(crate) fn pg_dumpall_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "pg_dumpall.exe"
+    } else {
+        "pg_dumpall"
+    }
+}
+
+pub(crate) fn psql_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "psql.exe"
+    } else {
+        "psql"
     }
 }
 

--- a/src/domain/postgres/mod.rs
+++ b/src/domain/postgres/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub(crate) mod cluster;
 pub(crate) mod connection;
 pub mod database;
 mod format;

--- a/src/services/config.rs
+++ b/src/services/config.rs
@@ -17,6 +17,8 @@ pub enum DbType {
     Mysql,
     Mariadb,
     Postgresql,
+    #[serde(rename = "postgresql-cluster")]
+    PostgresqlCluster,
     MongoDB,
     Sqlite,
     Redis,
@@ -31,6 +33,7 @@ impl DbType {
             DbType::Mysql => "mysql",
             DbType::Mariadb => "mariadb",
             DbType::Postgresql => "postgresql",
+            DbType::PostgresqlCluster => "postgresql-cluster",
             DbType::MongoDB => "mongodb",
             DbType::Sqlite => "sqlite",
             DbType::Redis => "redis",
@@ -169,21 +172,26 @@ impl ConfigService {
             }
 
             let username = match db.db_type {
-                DbType::Postgresql | DbType::Mysql | DbType::Mariadb | DbType::Mssql => {
-                    required(&db.username, &db.name, "username")?
-                }
+                DbType::Postgresql
+                | DbType::PostgresqlCluster
+                | DbType::Mysql
+                | DbType::Mariadb
+                | DbType::Mssql => required(&db.username, &db.name, "username")?,
                 _ => optional(&db.username),
             };
 
             let password = match db.db_type {
-                DbType::Postgresql | DbType::Mysql | DbType::Mariadb | DbType::Mssql => {
-                    required(&db.password, &db.name, "password")?
-                }
+                DbType::Postgresql
+                | DbType::PostgresqlCluster
+                | DbType::Mysql
+                | DbType::Mariadb
+                | DbType::Mssql => required(&db.password, &db.name, "password")?,
                 _ => optional(&db.password),
             };
 
             let host = match db.db_type {
                 DbType::Postgresql
+                | DbType::PostgresqlCluster
                 | DbType::Mysql
                 | DbType::Mariadb
                 | DbType::MongoDB
@@ -196,6 +204,7 @@ impl ConfigService {
 
             let port = match db.db_type {
                 DbType::Postgresql
+                | DbType::PostgresqlCluster
                 | DbType::Mysql
                 | DbType::Mariadb
                 | DbType::MongoDB
@@ -208,6 +217,10 @@ impl ConfigService {
 
             let database_name = match db.db_type {
                 DbType::Sqlite | DbType::Redis | DbType::Valkey => optional(&db.database),
+                DbType::PostgresqlCluster => db
+                    .database
+                    .clone()
+                    .unwrap_or_else(|| "postgres".to_string()),
                 _ => required(&db.database, &db.name, "database")?,
             };
 

--- a/src/services/storage/mod.rs
+++ b/src/services/storage/mod.rs
@@ -6,6 +6,7 @@ use crate::services::backup::models::{BackupResult, UploadResult};
 use crate::utils::common::BackupMethod;
 use async_trait::async_trait;
 use providers::azure_blob;
+use providers::google_cloud_storage;
 use providers::google_drive;
 use providers::local;
 use providers::s3;
@@ -34,6 +35,9 @@ pub fn get_provider(storage: &DatabaseStorage) -> Option<Box<dyn StorageProvider
         "s3" => Some(Box::new(s3::S3Provider {})),
         "blob" => Some(Box::new(azure_blob::AzureBlobProvider {})),
         "google-drive" => Some(Box::new(google_drive::GoogleDriveProvider {})),
+        "google-cloud-storage" => Some(Box::new(
+            google_cloud_storage::GoogleCloudStorageProvider {},
+        )),
         _ => {
             error!("Unknown storage provider: {}", storage.provider);
             None

--- a/src/services/storage/providers/azure_blob/helpers.rs
+++ b/src/services/storage/providers/azure_blob/helpers.rs
@@ -44,8 +44,6 @@ pub(crate) fn hmac_sha256_b64(key: &[u8], data: &str) -> Result<String> {
     Ok(STANDARD.encode(sig))
 }
 
-/// Build Service SAS query pairs (raw, un-encoded) for `canonical_resource`
-/// e.g. `/blob/{account}/{container}/{blob}`.
 pub fn build_service_sas(
     resolved: &ResolvedAzure,
     canonical_resource: &str,
@@ -81,7 +79,6 @@ pub fn build_service_sas(
     ])
 }
 
-/// Build a SAS-scoped URL for a blob (or container when `blob` is empty).
 pub fn build_sas_url(
     resolved: &ResolvedAzure,
     container: &str,
@@ -110,12 +107,10 @@ pub fn build_sas_url(
     Ok(url)
 }
 
-/// Default block size for the provider path (mirrors the S3 provider's PART_SIZE).
 pub const BLOCK_SIZE: usize = 100 * 1024 * 1024;
 
 type ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>;
 
-/// Stage one block under a zero-padded sequential id; records the RAW id bytes.
 async fn stage_block(
     bbc: &BlockBlobClient,
     index: u32,
@@ -132,13 +127,6 @@ async fn stage_block(
     Ok(())
 }
 
-/// Stream `body` to `{container}/{blob}` using Azure block upload. Never buffers the
-/// full payload: at most one `block_size` block plus one inbound chunk is resident
-/// (mirrors the S3 provider's per-part guarantee).
-///
-/// Assumes the container already exists — S3-faithful, no container creation. Uncommitted
-/// blocks are garbage-collected by Azure if `commit_block_list` is never reached, so no
-/// explicit abort is needed on the error path (unlike S3 multipart).
 pub async fn upload_stream_to_azure(
     resolved: &ResolvedAzure,
     container: &str,

--- a/src/services/storage/providers/azure_blob/mod.rs
+++ b/src/services/storage/providers/azure_blob/mod.rs
@@ -1,5 +1,5 @@
 pub mod helpers;
-mod models;
+pub(crate) mod models;
 
 use crate::core::context::Context;
 use crate::services::api::models::agent::status::DatabaseStorage;

--- a/src/services/storage/providers/azure_blob/models.rs
+++ b/src/services/storage/providers/azure_blob/models.rs
@@ -1,12 +1,17 @@
 use crate::services::storage::providers::azure_blob::helpers::ResolvedAzure;
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AzureBlobProviderConfig {
+    #[serde(default)]
     pub account_name: String,
+    #[serde(default)]
     pub account_key: String,
     pub container_name: String,
+    #[serde(default)]
+    pub auth_mode: Option<String>,
     #[serde(default)]
     pub connection_string: String,
     #[serde(default)]
@@ -25,9 +30,36 @@ fn parse_connection_string(cs: &str) -> std::collections::HashMap<String, String
         .collect()
 }
 
+
+pub(crate) fn ensure_account_in_endpoint(endpoint: &str, account: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if account.is_empty() {
+        return trimmed.to_string();
+    }
+    if let Ok(url) = Url::parse(trimmed) {
+        let host = url.host_str().unwrap_or("");
+        if host.contains(account) {
+            return trimmed.to_string();
+        }
+        let path = url.path().trim_matches('/');
+        if path == account || path.starts_with(&format!("{account}/")) {
+            return trimmed.to_string();
+        }
+    }
+    format!("{trimmed}/{account}")
+}
+
 impl AzureBlobProviderConfig {
     pub fn resolve(&self) -> Result<ResolvedAzure> {
-        if !self.connection_string.trim().is_empty() {
+        let mode = self.auth_mode.as_deref().unwrap_or("").trim();
+        let has_connection_string = !self.connection_string.trim().is_empty();
+
+        if mode == "connectionString" || (mode.is_empty() && has_connection_string) {
+            if !has_connection_string {
+                return Err(anyhow!(
+                    "authMode is connectionString but connectionString is empty"
+                ));
+            }
             let map = parse_connection_string(&self.connection_string);
             let account_name = map
                 .get("AccountName")
@@ -48,11 +80,22 @@ impl AzureBlobProviderConfig {
             });
         }
 
-        let blob_endpoint = self
+        if self.account_name.trim().is_empty() {
+            return Err(anyhow!("accountName required for accountKey auth"));
+        }
+        if self.account_key.trim().is_empty() {
+            return Err(anyhow!("accountKey required for accountKey auth"));
+        }
+
+        let blob_endpoint = match self
             .endpoint_url
-            .clone()
-            .filter(|s| !s.trim().is_empty())
-            .ok_or_else(|| anyhow!("endpointUrl required when connectionString is empty"))?;
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(endpoint) => ensure_account_in_endpoint(endpoint, &self.account_name),
+            None => format!("https://{}.blob.core.windows.net", self.account_name),
+        };
 
         Ok(ResolvedAzure {
             account_name: self.account_name.clone(),

--- a/src/services/storage/providers/azure_blob/models.rs
+++ b/src/services/storage/providers/azure_blob/models.rs
@@ -26,7 +26,6 @@ fn parse_connection_string(cs: &str) -> std::collections::HashMap<String, String
 }
 
 impl AzureBlobProviderConfig {
-    /// Resolve effective connection params, preferring the connection string when non-empty.
     pub fn resolve(&self) -> Result<ResolvedAzure> {
         if !self.connection_string.trim().is_empty() {
             let map = parse_connection_string(&self.connection_string);

--- a/src/services/storage/providers/google_cloud_storage/helpers.rs
+++ b/src/services/storage/providers/google_cloud_storage/helpers.rs
@@ -1,0 +1,122 @@
+use crate::services::storage::providers::google_cloud_storage::models::GoogleCloudStorageProviderConfig;
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use futures::Stream;
+use futures::StreamExt;
+use google_cloud_auth::credentials::Credentials;
+use google_cloud_storage::client::Storage;
+use google_cloud_storage::streaming_source::{SizeHint, StreamingSource};
+use std::pin::Pin;
+
+pub fn build_credentials(cfg: &GoogleCloudStorageProviderConfig) -> Result<Credentials> {
+    // Service-account JSON stores the PEM with `\n` escape sequences. When the key is
+    // carried through config as a JSON string those can arrive as literal two-char `\n`
+    // sequences rather than real newlines, so the PEM parser finds no `-----BEGIN-----`
+    // line ("no items found"). Normalize them back to real newlines. A PEM that already
+    // has real newlines contains no literal `\n` pairs, so this is a no-op for it.
+    let private_key = cfg.private_key.replace("\\n", "\n");
+
+    let key = serde_json::json!({
+        "type": "service_account",
+        "project_id": cfg.project_id,
+        "client_email": cfg.client_email,
+        "private_key": private_key,
+        "private_key_id": "",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "universe_domain": "googleapis.com",
+    });
+
+    google_cloud_auth::credentials::service_account::Builder::new(key)
+        .build()
+        .context("failed to build GCS service account credentials")
+}
+
+pub async fn build_client(cfg: &GoogleCloudStorageProviderConfig) -> Result<Storage> {
+    let endpoint = cfg.api_endpoint.as_deref().filter(|s| !s.trim().is_empty());
+
+    // A custom endpoint means a local emulator (fake-gcs-server), which does not verify
+    // credentials. Use anonymous creds so a dummy/empty `private_key` in the emulator
+    // config doesn't trip the service-account PEM parser. Real GCS still uses the
+    // service-account key built from config.
+    let builder = if let Some(ep) = endpoint {
+        let creds = google_cloud_auth::credentials::anonymous::Builder::new().build();
+        Storage::builder()
+            .with_credentials(creds)
+            .with_endpoint(ep.to_string())
+    } else {
+        Storage::builder().with_credentials(build_credentials(cfg)?)
+    };
+
+    builder.build().await.context("failed to build GCS client")
+}
+
+/// Bridges `build_stream`'s `Send`-only byte stream into the SDK's `StreamingSource`
+/// (which `send_buffered` requires to be `Send + Sync + 'static`) via a bounded mpsc
+/// channel. Also reports an exact `size_hint`: the SDK picks single-shot vs resumable
+/// upload from `size_hint().upper()` — an unknown bound forces resumable unconditionally
+/// (see `upload_with_client`).
+pub struct StreamSource {
+    rx: tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>,
+    total_size: u64,
+}
+
+impl StreamSource {
+    pub fn from_stream(
+        mut stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+        total_size: u64,
+    ) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(item) = stream.next().await {
+                if tx.send(item).await.is_err() {
+                    break;
+                }
+            }
+        });
+        StreamSource { rx, total_size }
+    }
+}
+
+impl StreamingSource for StreamSource {
+    type Error = std::io::Error;
+    async fn next(&mut self) -> Option<Result<Bytes, Self::Error>> {
+        self.rx.recv().await
+    }
+
+    // Report the exact size so the SDK can choose single-shot uploads. The default
+    // impl returns an unknown bound, which forces the resumable path unconditionally.
+    async fn size_hint(&self) -> Result<SizeHint, Self::Error> {
+        Ok(SizeHint::with_exact(self.total_size))
+    }
+}
+
+pub async fn upload_with_client(
+    client: &Storage,
+    bucket: &str,
+    object: &str,
+    source: StreamSource,
+    force_single_shot: bool,
+) -> Result<()> {
+    // `write_object` uses gRPC-style resource names: the bucket must be passed as
+    // `projects/_/buckets/<name>`, not the bare bucket id.
+    let bucket_resource = format!("projects/_/buckets/{bucket}");
+
+    let mut builder = client.write_object(bucket_resource, object, source);
+
+    // Resumable uploads follow a server-generated `Location` URL. When pointed at a
+    // custom `apiEndpoint` on a non-443 port, the SDK's transport drops the port from
+    // the `Host` header (google-cloud-gax-internal `host.rs`), so emulators that build
+    // the `Location` from `Host` hand back a portless URL the SDK then hangs on. A
+    // single-shot upload issues one request to the configured endpoint (no `Location`
+    // to follow), sidestepping the bug. We force it only for custom endpoints; against
+    // real GCS we keep resumable (bounded memory + resume on large backups).
+    if force_single_shot {
+        builder = builder.with_resumable_upload_threshold(usize::MAX);
+    }
+
+    builder
+        .send_buffered()
+        .await
+        .context("GCS write_object failed")?;
+    Ok(())
+}

--- a/src/services/storage/providers/google_cloud_storage/mod.rs
+++ b/src/services/storage/providers/google_cloud_storage/mod.rs
@@ -1,0 +1,148 @@
+pub mod helpers;
+mod models;
+
+use crate::core::context::Context;
+use crate::services::api::models::agent::status::DatabaseStorage;
+use crate::services::backup::models::{BackupResult, UploadResult};
+use crate::services::storage::StorageProvider;
+use crate::services::storage::providers::google_cloud_storage::helpers::{
+    StreamSource, build_client, upload_with_client,
+};
+use crate::services::storage::providers::google_cloud_storage::models::GoogleCloudStorageProviderConfig;
+use crate::utils::common::BackupMethod;
+use crate::utils::file::{full_file_name, full_file_path};
+use crate::utils::stream::build_stream;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::fs;
+use tracing::{error, info};
+
+pub struct GoogleCloudStorageProvider {}
+
+#[async_trait]
+impl StorageProvider for GoogleCloudStorageProvider {
+    async fn upload(
+        &self,
+        ctx: Arc<Context>,
+        result: BackupResult,
+        _method: BackupMethod,
+        storage: &DatabaseStorage,
+        encrypt: Option<bool>,
+    ) -> UploadResult {
+        let Some(file_path) = result.backup_file else {
+            return UploadResult {
+                storage_id: storage.id.clone(),
+                success: false,
+                error: Some("Missing backup file path".to_string()),
+                remote_file_path: None,
+                total_size: None,
+            };
+        };
+
+        let total_size = match fs::metadata(&file_path).await {
+            Ok(meta) => meta.len(),
+            Err(e) => {
+                error!("Failed to get file size: {}", e);
+                return UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    remote_file_path: None,
+                    total_size: None,
+                };
+            }
+        };
+
+        let encrypt = encrypt.unwrap_or(false);
+
+        let upload = match build_stream(&file_path, encrypt, &ctx.edge_key.master_key_b64).await {
+            Ok(u) => u,
+            Err(e) => {
+                error!("Stream build failed: {}", e);
+                return UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    remote_file_path: None,
+                    total_size: None,
+                };
+            }
+        };
+
+        let config: GoogleCloudStorageProviderConfig = match storage.clone().config.try_into() {
+            Ok(c) => c,
+            Err(e) => {
+                return UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    remote_file_path: None,
+                    total_size: None,
+                };
+            }
+        };
+
+        let file_name = full_file_name(encrypt);
+        info!("Uploading file {}", file_name);
+        let remote_file_path = full_file_path(&file_name);
+
+        let client = match build_client(&config).await {
+            Ok(c) => c,
+            Err(e) => {
+                error!("GCS client build failed: {:?}", e);
+                return UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    remote_file_path: None,
+                    total_size: None,
+                };
+            }
+        };
+
+        let source = StreamSource::from_stream(upload.stream, total_size);
+
+        // A custom apiEndpoint (self-hosted / emulator) on a non-443 port trips an
+        // upstream SDK bug in the resumable-upload path; force single-shot for it.
+        let force_single_shot = config
+            .api_endpoint
+            .as_deref()
+            .is_some_and(|s| !s.trim().is_empty());
+
+        info!(
+            "Starting GCS upload to {}/{} (single_shot={})",
+            config.bucket_name, remote_file_path, force_single_shot
+        );
+
+        match upload_with_client(
+            &client,
+            &config.bucket_name,
+            &remote_file_path,
+            source,
+            force_single_shot,
+        )
+        .await
+        {
+            Ok(_) => {
+                info!("GCS upload successful: {}", remote_file_path);
+                UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: true,
+                    error: None,
+                    remote_file_path: Some(remote_file_path),
+                    total_size: Some(total_size),
+                }
+            }
+            Err(e) => {
+                error!("GCS upload failed: {:?}", e);
+                UploadResult {
+                    storage_id: storage.id.clone(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    remote_file_path: None,
+                    total_size: Some(total_size),
+                }
+            }
+        }
+    }
+}

--- a/src/services/storage/providers/google_cloud_storage/models.rs
+++ b/src/services/storage/providers/google_cloud_storage/models.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GoogleCloudStorageProviderConfig {
+    pub project_id: String,
+    pub bucket_name: String,
+    pub client_email: String,
+    pub private_key: String,
+    #[serde(default)]
+    pub api_endpoint: Option<String>,
+}

--- a/src/services/storage/providers/mod.rs
+++ b/src/services/storage/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod azure_blob;
+pub mod google_cloud_storage;
 pub mod google_drive;
 pub mod local;
 pub mod s3;

--- a/src/tests/domain/cluster/backup.rs
+++ b/src/tests/domain/cluster/backup.rs
@@ -1,0 +1,53 @@
+use super::{env_for, start_cluster};
+use crate::domain::postgres::{cluster, connection};
+use crate::services::backup::logger::JobLogger;
+use crate::tests::init_tracing_for_test;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn produces_sql_with_roles_and_databases() {
+    init_tracing_for_test();
+    let (_c, cfg) = start_cluster("testuser").await;
+
+    let dir = TempDir::new().unwrap();
+    let logger = Arc::new(JobLogger::new());
+    let sql = cluster::backup::run(cfg.clone(), dir.path().to_path_buf(), env_for(&cfg), logger)
+        .await
+        .unwrap();
+
+    assert!(sql.is_file());
+    let contents = std::fs::read_to_string(&sql).unwrap();
+    assert!(contents.contains("CREATE ROLE"), "expected CREATE ROLE in dump");
+    assert!(
+        contents.contains("CREATE DATABASE") || contents.contains("\\connect"),
+        "expected database statements in dump"
+    );
+}
+
+#[tokio::test]
+async fn requires_superuser() {
+    init_tracing_for_test();
+    let (_c, super_cfg) = start_cluster("testuser").await;
+
+    // Create a NON-superuser login role on the cluster.
+    let client = connection::connect(&super_cfg).await.unwrap();
+    client
+        .batch_execute("CREATE ROLE appuser LOGIN PASSWORD 'changeme' NOSUPERUSER;")
+        .await
+        .unwrap();
+
+    let mut weak = super_cfg.clone();
+    weak.username = "appuser".to_string();
+
+    let dir = TempDir::new().unwrap();
+    let logger = Arc::new(JobLogger::new());
+    let err = cluster::backup::run(weak.clone(), dir.path().to_path_buf(), env_for(&weak), logger)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("superuser"),
+        "expected a superuser error, got: {err}"
+    );
+}

--- a/src/tests/domain/cluster/database.rs
+++ b/src/tests/domain/cluster/database.rs
@@ -1,0 +1,30 @@
+use crate::domain::factory::DatabaseFactory;
+use crate::services::config::{DatabaseConfig, DbType};
+use std::path::Path;
+
+fn cluster_config() -> DatabaseConfig {
+    DatabaseConfig {
+        name: "cluster".to_string(),
+        database: "postgres".to_string(),
+        db_type: DbType::PostgresqlCluster,
+        username: "postgres".to_string(),
+        password: "changeme".to_string(),
+        port: 5432,
+        host: "localhost".to_string(),
+        generated_id: "40875631-e3d2-4dfe-a26b-2a347ecc64fd".to_string(),
+        path: String::new(),
+        max_packet_size: String::new(),
+    }
+}
+
+#[tokio::test]
+async fn factory_routes_cluster_for_backup_with_sql_extension() {
+    let db = DatabaseFactory::create_for_backup(cluster_config()).await;
+    assert_eq!(db.file_extension(), ".sql");
+}
+
+#[tokio::test]
+async fn factory_routes_cluster_for_restore_with_sql_extension() {
+    let db = DatabaseFactory::create_for_restore(cluster_config(), Path::new("dump.sql")).await;
+    assert_eq!(db.file_extension(), ".sql");
+}

--- a/src/tests/domain/cluster/mod.rs
+++ b/src/tests/domain/cluster/mod.rs
@@ -1,0 +1,47 @@
+mod backup;
+mod database;
+mod restore;
+
+use crate::services::config::{DatabaseConfig, DbType};
+use std::collections::HashMap;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::postgres::Postgres;
+use url::Host;
+
+async fn start_cluster(user: &str) -> (ContainerAsync<Postgres>, DatabaseConfig) {
+    let container = Postgres::default()
+        .with_env_var("POSTGRES_DB", "postgres")
+        .with_env_var("POSTGRES_USER", user)
+        .with_env_var("POSTGRES_PASSWORD", "changeme")
+        .with_tag("17")
+        .start()
+        .await
+        .unwrap();
+
+    let host = container
+        .get_host()
+        .await
+        .unwrap_or(Host::parse("127.0.0.1").unwrap());
+    let port = container.get_host_port_ipv4(5432).await.unwrap_or(5432);
+
+    let config = DatabaseConfig {
+        name: format!("cluster-{}", user),
+        database: "postgres".to_string(),
+        db_type: DbType::PostgresqlCluster,
+        username: user.to_string(),
+        password: "changeme".to_string(),
+        port,
+        host: host.to_string(),
+        generated_id: "40875631-e3d2-4dfe-a26b-2a347ecc64fd".to_string(),
+        path: "".to_string(),
+        max_packet_size: "".to_string(),
+    };
+    (container, config)
+}
+
+fn env_for(cfg: &DatabaseConfig) -> HashMap<String, String> {
+    let mut env = std::env::vars().collect::<HashMap<_, _>>();
+    env.insert("PGPASSWORD".to_string(), cfg.password.clone());
+    env
+}

--- a/src/tests/domain/cluster/restore.rs
+++ b/src/tests/domain/cluster/restore.rs
@@ -1,0 +1,83 @@
+use super::{env_for, start_cluster};
+use crate::domain::postgres::{cluster, connection};
+use crate::services::backup::logger::JobLogger;
+use crate::tests::init_tracing_for_test;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn backup_restore_round_trip_preserves_ownership() {
+    init_tracing_for_test();
+
+    // Source cluster A: seed a role + a table owned by that role.
+    let (_a, src) = start_cluster("testuser").await;
+    let client = connection::connect(&src).await.unwrap();
+    client
+        .batch_execute(
+            "CREATE ROLE appowner LOGIN PASSWORD 'changeme' NOSUPERUSER;\n\
+             CREATE TABLE owned_tbl (id int);\n\
+             ALTER TABLE owned_tbl OWNER TO appowner;",
+        )
+        .await
+        .unwrap();
+
+    let dir = TempDir::new().unwrap();
+    let sql = cluster::backup::run(src.clone(), dir.path().to_path_buf(), env_for(&src), Arc::new(JobLogger::new()))
+        .await
+        .unwrap();
+
+    // Target cluster B: fresh, same bootstrap user.
+    let (_b, mut dst) = start_cluster("testuser").await;
+
+    cluster::restore::run(dst.clone(), sql.clone(), env_for(&dst), Arc::new(JobLogger::new()))
+        .await
+        .unwrap();
+
+    // Verify the seeded role exists and the table's owner was preserved on B.
+    dst.database = "postgres".to_string();
+    let bclient = connection::connect(&dst).await.unwrap();
+    let role_exists: bool = bclient
+        .query_one("SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appowner');", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert!(role_exists, "appowner role must be recreated on the target");
+
+    let owner: String = bclient
+        .query_one(
+            "SELECT tableowner FROM pg_tables WHERE tablename = 'owned_tbl';",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(owner, "appowner", "table ownership must be preserved");
+}
+
+#[tokio::test]
+async fn requires_superuser() {
+    init_tracing_for_test();
+    let (_c, super_cfg) = start_cluster("testuser").await;
+
+    // A non-superuser login role must be rejected before psql runs.
+    let client = connection::connect(&super_cfg).await.unwrap();
+    client
+        .batch_execute("CREATE ROLE appuser LOGIN PASSWORD 'changeme' NOSUPERUSER;")
+        .await
+        .unwrap();
+
+    let mut weak = super_cfg.clone();
+    weak.username = "appuser".to_string();
+
+    // The superuser pre-check happens before the dump file is read, so a
+    // non-existent restore path is fine — it must never be touched.
+    let missing = std::path::PathBuf::from("/nonexistent/cluster.sql");
+    let err = cluster::restore::run(weak.clone(), missing, env_for(&weak), Arc::new(JobLogger::new()))
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("superuser"),
+        "expected a superuser error, got: {err}"
+    );
+}

--- a/src/tests/domain/mod.rs
+++ b/src/tests/domain/mod.rs
@@ -2,6 +2,7 @@ mod mariadb;
 mod mongodb;
 mod mysql;
 mod postgres;
+mod cluster;
 mod redis;
 mod valkey;
 mod firebird;

--- a/src/tests/domain/postgres.rs
+++ b/src/tests/domain/postgres.rs
@@ -57,6 +57,20 @@ async fn postgres_ping_test() {
 }
 
 #[tokio::test]
+async fn is_superuser_detects_superuser_role() {
+    init_tracing_for_test();
+
+    // The testcontainer's POSTGRES_USER ("testuser") is the bootstrap superuser.
+    let (_container, config) = create_config().await;
+
+    let is_super = crate::domain::postgres::connection::is_superuser(&config)
+        .await
+        .unwrap();
+
+    assert!(is_super);
+}
+
+#[tokio::test]
 async fn postgres_backup_restore_test() {
     init_tracing_for_test();
 
@@ -152,7 +166,8 @@ async fn postgres_password_with_slash_test() {
 
 mod select_pg_path_tests {
     use crate::domain::postgres::connection::{
-        pg_dump_binary_name, pg_dump_exists_in, select_pg_path_with,
+        pg_dump_binary_name, pg_dump_exists_in, pg_dumpall_binary_name, psql_binary_name,
+        select_pg_path_with,
     };
 
     // `select_pg_path_with` takes the `PG_BIN_DIR` override as a plain
@@ -208,5 +223,25 @@ mod select_pg_path_tests {
     fn pg_dump_exists_in_is_false_for_nonexistent_dir() {
         let dir = std::path::Path::new("this/path/almost-certainly/does-not-exist-12345");
         assert!(!pg_dump_exists_in(dir));
+    }
+
+    #[test]
+    fn pg_dumpall_binary_name_is_platform_specific() {
+        let name = pg_dumpall_binary_name();
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "pg_dumpall.exe");
+        } else {
+            assert_eq!(name, "pg_dumpall");
+        }
+    }
+
+    #[test]
+    fn psql_binary_name_is_platform_specific() {
+        let name = psql_binary_name();
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "psql.exe");
+        } else {
+            assert_eq!(name, "psql");
+        }
     }
 }

--- a/src/tests/services/config_tests.rs
+++ b/src/tests/services/config_tests.rs
@@ -1,0 +1,79 @@
+use crate::core::context::Context;
+use crate::services::api::ApiClient;
+use crate::services::config::ConfigService;
+use crate::utils::edge_key::EdgeKey;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+
+// `ConfigService::load` never touches `self.ctx` on the `Some(file_path)` path,
+// so the values here don't matter — but `Context::new()` panics without an
+// `EDGE_KEY` env var, so build the struct directly (mirrors
+// backup_uploader_tests.rs's `ctx_pointing_at`).
+fn test_context() -> Arc<Context> {
+    Arc::new(Context {
+        edge_key: EdgeKey {
+            server_url: String::new(),
+            agent_id: "agent-1".to_string(),
+            master_key_b64: String::new(),
+        },
+        api: ApiClient::new(String::new()),
+    })
+}
+
+fn write_json(contents: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".json").unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    file
+}
+
+#[test]
+fn parses_postgresql_cluster_type() {
+    let file = write_json(
+        r#"{
+            "databases": [
+                {
+                    "name": "cluster1",
+                    "type": "postgresql-cluster",
+                    "username": "postgres",
+                    "password": "p",
+                    "port": 5432,
+                    "host": "localhost",
+                    "generated_id": "16678159-ff7e-4c97-8c83-0adeff214681"
+                }
+            ]
+        }"#,
+    );
+
+    let service = ConfigService::new(test_context());
+    let cfg = service.load(Some(file.path().to_str().unwrap())).unwrap();
+
+    assert_eq!(cfg.databases[0].db_type.as_str(), "postgresql-cluster");
+    // `database` is optional for cluster entries and defaults to "postgres".
+    assert_eq!(cfg.databases[0].database, "postgres");
+}
+
+#[test]
+fn postgresql_cluster_respects_explicit_database() {
+    let file = write_json(
+        r#"{
+            "databases": [
+                {
+                    "name": "cluster1",
+                    "type": "postgresql-cluster",
+                    "database": "maintenance",
+                    "username": "postgres",
+                    "password": "p",
+                    "port": 5432,
+                    "host": "localhost",
+                    "generated_id": "16678159-ff7e-4c97-8c83-0adeff214681"
+                }
+            ]
+        }"#,
+    );
+
+    let service = ConfigService::new(test_context());
+    let cfg = service.load(Some(file.path().to_str().unwrap())).unwrap();
+
+    assert_eq!(cfg.databases[0].database, "maintenance");
+}

--- a/src/tests/services/mod.rs
+++ b/src/tests/services/mod.rs
@@ -1,2 +1,3 @@
 mod api_models_tests;
 mod backup_uploader_tests;
+mod config_tests;

--- a/src/tests/storage/azure_blob.rs
+++ b/src/tests/storage/azure_blob.rs
@@ -16,9 +16,7 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers::{GenericImage, ImageExt};
 use url::Url;
 
-/// Build an Account SAS query set (test-only). Azurite cannot authorize container-create with
-/// a container-scoped Service SAS, so tests create the target container with an Account SAS.
-/// Reuses the production HMAC primitive (`hmac_sha256_b64`) to avoid duplicating signing logic.
+
 fn build_account_sas(
     resolved: &ResolvedAzure,
     services: &str,
@@ -33,12 +31,9 @@ fn build_account_sas(
     let signed_expiry = (Utc::now() + Duration::hours(1))
         .format("%Y-%m-%dT%H:%M:%SZ")
         .to_string();
-    let signed_protocol = "https,http"; // Azurite is http
+    let signed_protocol = "https,http";
     let signed_ip = String::new();
     let encryption_scope = String::new();
-
-    // Account SAS string-to-sign for sv >= 2020-12-06:
-    // account \n sp \n ss \n srt \n st \n se \n sip \n spr \n sv \n ses \n  (trailing newline)
     let string_to_sign = format!(
         "{acc}\n{sp}\n{ss}\n{srt}\n{st}\n{se}\n{sip}\n{spr}\n{sv}\n{ses}\n",
         acc = resolved.account_name, sp = permissions, ss = services, srt = resource_types,
@@ -59,7 +54,6 @@ fn build_account_sas(
     ])
 }
 
-/// Build an Account-SAS-scoped URL for a container (test-only container creation).
 fn build_account_sas_container_url(
     resolved: &ResolvedAzure,
     container: &str,
@@ -86,21 +80,12 @@ const AZURITE_KEY: &str =
 async fn start_azurite() -> (testcontainers::ContainerAsync<GenericImage>, ResolvedAzure) {
     let container = GenericImage::new("mcr.microsoft.com/azure-storage/azurite", "latest")
         .with_exposed_port(10000.tcp())
-        // The current `latest` image logs (on stdout):
-        //   "Azurite Blob service successfully listens on http://0.0.0.0:10000"
-        // Older builds phrased it "...is successfully listening"; this substring matches
-        // the wording the pulled image actually emits.
         .with_wait_for(WaitFor::message_on_stdout(
             "Azurite Blob service successfully listens on",
         ))
-        // The GA SDK sends a very recent `x-ms-version`; Azurite 3.35 rejects unknown
-        // versions unless we tell it to skip that check.
         .with_cmd(["azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck"])
         .start().await.unwrap();
-    // Use the testcontainers-resolved host (not a hardcoded 127.0.0.1): under
-    // docker-out-of-docker / remote daemons the published port is not on the test
-    // process's loopback. All other container tests (mssql, valkey, postgres, ...)
-    // already do this; azure_blob was the only one hardcoding the host.
+
     let host = container.get_host().await.unwrap().to_string();
     let port = container.get_host_port_ipv4(10000).await.unwrap();
     let resolved = ResolvedAzure {
@@ -118,8 +103,7 @@ async fn spike_sas_block_roundtrip_against_azurite() {
     let container = "portabase";
     let blob = "spike/hello.txt";
 
-    // Container creation must use an Account SAS (service=blob, resource-type=container,
-    // perms=create+write). Azurite cannot authorize container-create with a Service SAS.
+
     let container_url =
         build_account_sas_container_url(&resolved, container, "b", "c", "cw").unwrap();
     let container_client =
@@ -135,15 +119,91 @@ async fn spike_sas_block_roundtrip_against_azurite() {
     bbc.stage_block(&raw_id, payload.len() as u64, RequestContent::from(payload.to_vec()), None)
         .await.unwrap();
 
-    // `BlockLookupList.latest` is `Option<Vec<Vec<u8>>>` and base64-encodes each entry
-    // internally during XML serialization, exactly as `stage_block` base64-encodes the
-    // `blockid` query. So `latest` must hold the SAME RAW id bytes passed to `stage_block`.
     let block_list = BlockLookupList { latest: Some(vec![raw_id.clone()]), ..Default::default() };
     bbc.commit_block_list(block_list.try_into().unwrap(), None).await.unwrap();
 
     let read_url = build_sas_url(&resolved, container, blob, SasResource::Blob, "r").unwrap();
     let read_client = BlobClient::new(read_url, None, None).unwrap();
     assert!(read_client.exists().await.unwrap());
+}
+
+mod resolve {
+    use crate::services::storage::providers::azure_blob::models::{
+        AzureBlobProviderConfig, ensure_account_in_endpoint,
+    };
+
+    const AZURITE_KEY: &str =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    const CONNECTION_STRING: &str = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;TableEndpoint=http://localhost:10002/devstoreaccount1;";
+
+
+    #[test]
+    fn resolve_connection_string_mode() {
+        let cfg = AzureBlobProviderConfig {
+            account_name: String::new(),
+            account_key: String::new(),
+            container_name: "portabase".into(),
+            auth_mode: Some("connectionString".into()),
+            connection_string: CONNECTION_STRING.into(),
+            endpoint_url: None,
+        };
+        let r = cfg.resolve().unwrap();
+        assert_eq!(r.account_name, "devstoreaccount1");
+        assert_eq!(r.account_key, AZURITE_KEY);
+        assert_eq!(r.blob_endpoint, "http://localhost:10000/devstoreaccount1");
+    }
+
+
+    #[test]
+    fn resolve_account_key_mode_injects_account_path() {
+        let cfg = AzureBlobProviderConfig {
+            account_name: "devstoreaccount1".into(),
+            account_key: AZURITE_KEY.into(),
+            container_name: "portabase".into(),
+            auth_mode: Some("accountKey".into()),
+            connection_string: CONNECTION_STRING.into(),
+            endpoint_url: Some("http://localhost:10000".into()),
+        };
+        let r = cfg.resolve().unwrap();
+        assert_eq!(r.account_name, "devstoreaccount1");
+        assert_eq!(r.account_key, AZURITE_KEY);
+        assert_eq!(r.blob_endpoint, "http://localhost:10000/devstoreaccount1");
+    }
+
+    #[test]
+    fn resolve_implicit_connection_string() {
+        let cfg = AzureBlobProviderConfig {
+            account_name: String::new(),
+            account_key: String::new(),
+            container_name: "portabase".into(),
+            auth_mode: None,
+            connection_string: CONNECTION_STRING.into(),
+            endpoint_url: None,
+        };
+        let r = cfg.resolve().unwrap();
+        assert_eq!(r.blob_endpoint, "http://localhost:10000/devstoreaccount1");
+    }
+
+    #[test]
+    fn resolve_account_key_default_endpoint() {
+        let cfg = AzureBlobProviderConfig {
+            account_name: "myaccount".into(),
+            account_key: AZURITE_KEY.into(),
+            container_name: "portabase".into(),
+            auth_mode: Some("accountKey".into()),
+            connection_string: String::new(),
+            endpoint_url: None,
+        };
+        let r = cfg.resolve().unwrap();
+        assert_eq!(r.blob_endpoint, "https://myaccount.blob.core.windows.net");
+    }
+
+    #[test]
+    fn ensure_account_keeps_host_style_endpoint() {
+        let got =
+            ensure_account_in_endpoint("https://myaccount.blob.core.windows.net", "myaccount");
+        assert_eq!(got, "https://myaccount.blob.core.windows.net");
+    }
 }
 
 #[tokio::test]
@@ -156,7 +216,6 @@ async fn upload_stream_multi_block_roundtrip() {
     let container = "portabase";
     let blob = "backups/multi.bin";
 
-    // Container setup (provider itself never creates it): Account SAS create.
     let container_url =
         build_account_sas_container_url(&resolved, container, "b", "c", "cw").unwrap();
     azure_storage_blob::clients::BlobContainerClient::new(container_url, None, None)
@@ -165,7 +224,6 @@ async fn upload_stream_multi_block_roundtrip() {
         .await
         .unwrap();
 
-    // 10 KiB fed as 1 KiB chunks, forced into 4 KiB blocks => 3 blocks (multi-block path).
     let data = vec![7u8; 10 * 1024];
     let chunks: Vec<Result<Bytes, std::io::Error>> = data
         .chunks(1024)
@@ -177,7 +235,6 @@ async fn upload_stream_multi_block_roundtrip() {
         .await
         .unwrap();
 
-    // Verify the committed blob reassembles to the exact source bytes via a read-SAS GET.
     let read_url = build_sas_url(&resolved, container, blob, SasResource::Blob, "r").unwrap();
     let got = reqwest::get(read_url).await.unwrap().bytes().await.unwrap();
     assert_eq!(got.as_ref(), data.as_slice());

--- a/src/tests/storage/google_cloud_storage.rs
+++ b/src/tests/storage/google_cloud_storage.rs
@@ -1,0 +1,99 @@
+use crate::services::storage::providers::google_cloud_storage::helpers::{
+    StreamSource, upload_with_client,
+};
+use crate::tests::init_tracing_for_test;
+
+use bytes::Bytes;
+use futures::stream;
+use google_cloud_storage::client::Storage;
+use testcontainers::core::{IntoContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{GenericImage, ImageExt};
+
+const BUCKET: &str = "portabase";
+
+async fn start_fake_gcs() -> (testcontainers::ContainerAsync<GenericImage>, String) {
+    // Natural random host port (no port-80 pin). The provider forces a single-shot
+    // upload for custom endpoints, which issues one request to this endpoint and never
+    // follows a server-built `Location` — so it works on any port, unlike the resumable
+    // path that the SDK's Host-header port-drop bug breaks on non-443 ports.
+    let container = GenericImage::new("fsouza/fake-gcs-server", "latest")
+        .with_exposed_port(4443.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("server started at"))
+        .with_cmd(["-scheme", "http", "-backend", "memory", "-port", "4443"])
+        .start()
+        .await
+        .unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(4443).await.unwrap();
+    let endpoint = format!("http://{host}:{port}");
+    (container, endpoint)
+}
+
+async fn anon_client(endpoint: &str) -> Storage {
+    let creds = google_cloud_auth::credentials::anonymous::Builder::new().build();
+    Storage::builder()
+        .with_credentials(creds)
+        .with_endpoint(endpoint.to_string())
+        .build()
+        .await
+        .unwrap()
+}
+
+async fn create_bucket(endpoint: &str) {
+    let url = format!("{endpoint}/storage/v1/b?project=test-project");
+    let res = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({ "name": BUCKET }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        res.status().is_success(),
+        "bucket create failed: {}",
+        res.status()
+    );
+}
+
+#[tokio::test]
+async fn upload_stream_roundtrip_against_fake_gcs() {
+    init_tracing_for_test();
+    let (_container, endpoint) = start_fake_gcs().await;
+    create_bucket(&endpoint).await;
+
+    let object = "backups/multi.bin";
+
+    // 10 KiB fed as 1 KiB chunks -> multi-chunk streaming path.
+    let data = vec![7u8; 10 * 1024];
+    let chunks: Vec<Result<Bytes, std::io::Error>> = data
+        .chunks(1024)
+        .map(|c| Ok(Bytes::copy_from_slice(c)))
+        .collect();
+    let source = StreamSource::from_stream(Box::pin(stream::iter(chunks)), data.len() as u64);
+
+    let client = anon_client(&endpoint).await;
+
+    // force_single_shot = true (custom endpoint). Guard with a timeout so a regression
+    // into the resumable path (which would hang forever on this non-443 port) fails the
+    // test instead of stalling it.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        upload_with_client(&client, BUCKET, object, source, true),
+    )
+    .await
+    .expect("upload hung (regressed to resumable path on a non-443 endpoint?)")
+    .unwrap();
+
+    let read_url = format!(
+        "{endpoint}/storage/v1/b/{BUCKET}/o/{}?alt=media",
+        object.replace('/', "%2F")
+    );
+    let got = reqwest::get(&read_url)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(got.as_ref(), data.as_slice());
+}

--- a/src/tests/storage/mod.rs
+++ b/src/tests/storage/mod.rs
@@ -1,1 +1,2 @@
 mod azure_blob;
+mod google_cloud_storage;


### PR DESCRIPTION
* feat: add as_str/from_str to PostgresDumpFormat

* feat: resolve pg_dumpall/psql binary names

* feat: add include_globals field to database config

* feat: add pg_dumpall/psql globals dump and apply

* feat: add postgres backup bundle (manifest + build + resolve)

* feat: bundle globals into postgres backup when include_globals is set

* feat: replay globals before pg_restore when backup archive is a bundle

* refactor: bind FD restore tempdir guard once to clear unused warnings

* docs: demonstrate include_globals in sample databases.json

* chore: silence test-only re-export warning in non-test builds

* revert: remove include_globals feature, restore plain pg_dump/pg_restore

* feat: add pg_dumpall/psql binary names and is_superuser check

* feat: add postgresql-cluster db type and config parsing

* feat: pg_dumpall cluster backup and psql restore

* feat: route postgresql-cluster through PostgresClusterDatabase

* docs: add postgresql-cluster sample to databases.json

* refactor: split cluster mode into cluster/ module (backup, restore, database)

* test: mirror cluster tests into src/tests/domain/cluster/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL cluster backups and restores.
  * Added Google Cloud Storage as a new backup storage option.
  * PostgreSQL cluster configurations now accept the `postgresql-cluster` database type and default to the `postgres` database when not set.

* **Bug Fixes**
  * Improved handling of PostgreSQL command execution across platforms.
  * Backup and restore flows now validate required database permissions earlier and provide clearer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->