### PR TITLE
fix: postgres cluster dump command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       APP_ENV: development
       LOG: debug
       TZ: "Europe/Paris"
-      EDGE_KEY: "eyJzZXJ2ZXJVcmwiOiJodHRwOi8vbG9jYWxob3N0Ojg4ODciLCJhZ2VudElkIjoiNzY1OGIzYjctNjg5MC00MjllLThkN2QtNjU2ZjlmYTJlMDRjIiwibWFzdGVyS2V5QjY0IjoiQlhWM1hvbEM2NTZTVjdkTmdjV1BHUWxrKytycExJNmxHRGk3Q1BCNWllbz0ifQ=="
+      EDGE_KEY: "eyJzZXJ2ZXJVcmwiOiJodHRwOi8vbG9jYWxob3N0Ojg4ODciLCJhZ2VudElkIjoiNWE2YjcxMDgtMGJhYS00Yjg1LTgwMmMtNTNjNjJiMDAzZDgzIiwibWFzdGVyS2V5QjY0IjoiMUh0djdtWCtYVkJxL0IzUEV2WDlZZjlQeUdVZW5oRHlXemo5THRqNW90WT0ifQ=="
       #CHUNK_SIZE_MB: "1"
       #POOLING: 1
       #DATABASES_CONFIG_FILE: "config.toml"

--- a/src/domain/postgres/cluster/backup.rs
+++ b/src/domain/postgres/cluster/backup.rs
@@ -50,6 +50,8 @@ pub async fn run(
             .arg("--host").arg(&cfg.host)
             .arg("--port").arg(cfg.port.to_string())
             .arg("--username").arg(&cfg.username)
+            .arg("--clean")
+            .arg("--if-exists")
             .arg("-v")
             .arg("-f").arg(&file_path)
             .envs(env)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster backups now include safer drop statements for existing objects when restoring, helping avoid conflicts during recovery.

* **Chores**
  * Updated a service configuration value in the deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->